### PR TITLE
Use an available version of clang

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -30,11 +30,11 @@ RUN curl --silent --show-error https://dl.yarnpkg.com/debian/pubkey.gpg \
 # Install dependencies.
 RUN apt-get update && \
   apt-get install --yes \
-  nodejs=9.4.0-1nodesource1 \
+  nodejs \
   yarn=1.3.2-1 \
   netcat-openbsd=1.130-3 \
   cmake \
-  clang-5.0 \
+  clang-3.9 \
   zlib1g-dev
 
 # Install Rust.


### PR DESCRIPTION
5.0 does not exist in Debian Stretch, but 3.9 does. Both versions work fine for what we need (simple C++ compilation).