### PR TITLE
Update Rust to 1.26.0

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -37,27 +37,32 @@ RUN apt-get update && \
   clang-3.9 \
   zlib1g-dev
 
-# Install Rust.
+# Setup Rust variables and versions.
 ENV RUSTUP_HOME=/usr/local/rustup \
     CARGO_HOME=/usr/local/cargo \
     PATH=/usr/local/cargo/bin:$PATH \
     rustArch='x86_64-unknown-linux-gnu' \
-    rustupSha256='4b7a67cd971d713e0caef48b5754190aca19192d1863927a005c3432512b12dc'
+    rustToolchain='1.26.0' \
+    rustupVersion='1.11.0' \
+    rustupSha256='c9837990bce0faab4f6f52604311a19bb8d2cde989bea6a7b605c8e526db6f02' \
+    rustClippyNightly='nightly-2018-05-20' \
+    clippyVersion='0.0.203'
 
+# Install Rust.
 RUN set -eux; \
-    url="https://static.rust-lang.org/rustup/archive/1.9.0/${rustArch}/rustup-init"; \
+    url="https://static.rust-lang.org/rustup/archive/${rustupVersion}/${rustArch}/rustup-init"; \
     wget "$url"; \
     echo "${rustupSha256} *rustup-init" | sha256sum -c -; \
     chmod +x rustup-init; \
-    ./rustup-init -y --no-modify-path --default-toolchain nightly-2018-01-20; \
+    ./rustup-init -y --no-modify-path --default-toolchain "${rustToolchain}"; \
     rm rustup-init; \
     chmod -R a+w $RUSTUP_HOME $CARGO_HOME; \
+    rustup install "${rustClippyNightly}"; \
+    rustup show; \
     rustup --version; \
     cargo --version; \
     rustc --version;
 
-RUN cargo install --version 0.0.180 clippy;
-
-# The force flag is needed because rustup thinks cargo fmt work's but it isn't
-# installed. This might be because it failed the build for nightly.
-RUN cargo install --force --version 0.3.6 rustfmt-nightly;
+# Install rustfmt and clippy
+RUN rustup component add rustfmt-preview; \
+    cargo "+${rustClippyNightly}" install --version "${clippyVersion}" clippy;

--- a/Dockerfile
+++ b/Dockerfile
@@ -57,12 +57,14 @@ RUN set -eux; \
     ./rustup-init -y --no-modify-path --default-toolchain "${rustToolchain}"; \
     rm rustup-init; \
     chmod -R a+w $RUSTUP_HOME $CARGO_HOME; \
-    rustup install "${rustClippyNightly}"; \
-    rustup show; \
     rustup --version; \
     cargo --version; \
     rustc --version;
 
-# Install rustfmt and clippy
-RUN rustup component add rustfmt-preview; \
-    cargo "+${rustClippyNightly}" install --version "${clippyVersion}" clippy;
+# Install clippy.
+RUN rustup install "${rustClippyNightly}"; \
+    cargo "+${rustClippyNightly}" install --version "${clippyVersion}" clippy; \
+    rustup uninstall "${rustClippyNightly}";
+
+# Install rustfmt.
+RUN rustup component add rustfmt-preview;

--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ A docker image with the tools needed to compile and test [forte-music/core]. It
 includes:
 
 * a node environment with yarn
-* a nightly rust toolchain (2018-01-20) along with clippy and rustfmt
+* a stable rust toolchain along with clippy and rustfmt
 * [wait-for]
 * clang
 * cmake


### PR DESCRIPTION
This updates Rust to stable while also updating some of the other Rust tools. The versions are pulled into variables, so in the future it will be easy to update again.

Updated items:
- Rust; `nightly-2018-01-20` to `1.26.0` (and also installs `nightly-2018-05-20` for Clippy)
- Rustup; `1.9.0` to `1.11.0`
- Rustfmt; `0.3.6` to the version associated with the installed stable version of Rust, which for `1.26.0` is `0.4.1`
- Clippy; `0.0.180` to `0.0.203`

Closes #4